### PR TITLE
Update elements.py

### DIFF
--- a/omniture/elements.py
+++ b/omniture/elements.py
@@ -12,7 +12,7 @@ class Value(object):
     """ Searchable Dict. Can search on both the key and the value """
     def __init__(self, title, id, parent, extra={}):
         self.log = logging.getLogger(__name__)
-        self.title = str(title)
+        self.title = unicode(title)
         self.id = id
         self.parent = parent
         self.properties = {'id': id}


### PR DESCRIPTION
This fix resolve UnicodeEncodeError on line 26 when item[title] contains UnicodeChar. 

For example if SegmentTitle contains RIGHT DOUBLE QUOTATION MARK (U+201D) or LEFT DOUBLE QUOTATION MARK (U+201C) now the cast str(title) raise an UnicodeEncodeError. Change the cast to unicode() fix the problem. 