### PR TITLE
check metric == 'INF'

### DIFF
--- a/omniture/elements.py
+++ b/omniture/elements.py
@@ -12,7 +12,7 @@ class Value(object):
     """ Searchable Dict. Can search on both the key and the value """
     def __init__(self, title, id, parent, extra={}):
         self.log = logging.getLogger(__name__)
-        self.title = str(title)
+        self.title = title
         self.id = id
         self.parent = parent
         self.properties = {'id': id}

--- a/omniture/reports.py
+++ b/omniture/reports.py
@@ -150,11 +150,13 @@ class Report(object):
                 data_set.extend(self.parse_rows(row['breakdown'], level+1, data))
             elif 'counts' in row:
                 for index, metric in enumerate(row['counts']):
-                        #decide what type of event
-                        if self.metrics[index].decimals > 0 or metric.find('.') >-1:
-                            data[str(self.metrics[index].id)] = float(metric)
-                        else:
-                            data[str(self.metrics[index].id)] = int(metric)
+                    if metric == 'INF':
+                        metric = u'0'
+                    #decide what type of event
+                    if self.metrics[index].decimals > 0 or metric.find('.') >-1:
+                        data[str(self.metrics[index].id)] = float(metric)
+                    else:
+                        data[str(self.metrics[index].id)] = int(metric)
 
 
 


### PR DESCRIPTION
we've noticed that under some circumstances Omniture could return as metric the value `u'INF'`.
In those cases the cast `int(metric)` fail and raise an Exception.