### PR TITLE
fix for privilege error when passing segments in report request

### DIFF
--- a/omniture/account.py
+++ b/omniture/account.py
@@ -193,11 +193,15 @@ class Suite(Value):
     @utils.memoize
     def segments(self):
         """ Return the list of valid segments for the current report suite """
-        if self.account.cache:
-            data = self.request_cached('Segments', 'Get',{"accessLevel":"shared"})
-        else:
-            data = self.request('Segments', 'Get',{"accessLevel":"shared"})
-        return Value.list('segments', data, self, 'name', 'id',)
+        try:
+            if self.account.cache:
+                data = self.request_cached('Segments', 'Get',{"accessLevel":"shared"})
+            else:
+                data = self.request('Segments', 'Get',{"accessLevel":"shared"})
+            return Value.list('segments', data, self, 'name', 'id',)
+        except reports.InvalidReportError:
+            data = []
+            return Value.list('segments', data, self, 'name', 'id',)
 
     @property
     def report(self):

--- a/omniture/reports.py
+++ b/omniture/reports.py
@@ -8,6 +8,7 @@ import json
 
 from .elements import Value
 
+import warnings
 
 class InvalidReportError(Exception):
     """
@@ -71,7 +72,11 @@ class Report(object):
         if segments:
             self.segments = []
             for s in segments:
-                self.segments.append(self.query.suite.segments[s['id']])
+                try:
+                    self.segments.append(self.query.suite.segments[s['id']])
+                except KeyError as e:
+                    warnings.warn(repr(e))
+                    self.segments.append(s['id'])
         else:
             self.segments = None
 


### PR DESCRIPTION
My fix for issue https://github.com/dancingcactus/python-omniture/issues/20 when trying to access `suit.segments`, or `report.filter`.

This patched code now returns `suite.segments` as an empty list, instead of completely failing.

Due to not being able to access segments, `report.filter` will not work because segments cannot be verified (i.e. id cannot be normalized), instead you can force the segment into your query using: 

`report = report.set("segments", [{"id" : "YOUR-SEGMENT-ID"}])`

After running the report, during processing of data, this patch will produce the `KeyError` for unverified segment as a `Warning` instead, and continue to give you the data.

Is this worthy?